### PR TITLE
Fixed mkdir flow for MacOS

### DIFF
--- a/src/util/FileUtil.ts
+++ b/src/util/FileUtil.ts
@@ -12,10 +12,12 @@ export function mkDirByPathSync(targetDir:string, {isRelativeToScript = false} =
   targetDir.split(sep).reduce((parentDir, childDir) => {
     const curDir = path.resolve(baseDir, parentDir, childDir);
     try {
-      fs.mkdirSync(curDir);
+      if (!fs.existsSync(curDir)) {
+        fs.mkdirSync(curDir);
+      }
       //console.log(`Directory ${curDir} created!`);
     } catch (err) {
-      if (err.code !== 'EEXIST' && 
+      if (err.code !== 'EEXIST' && err.code !== "EISDIR" &&
           !(err.code == 'EPERM' && curDir == "C:\\") ) {
         throw err;
       }


### PR DESCRIPTION
Independent from how the output directory is specified,

* `--output="./output"`
* `--output="/Users/<username/.../output"`

the script determines the absolute path, and then goes (MacOS):
```
Directory /
Directory /Users
Directory /Users/<username>
...
```
And throws the `EISDIR` error trying to create directory `/` on MacOS.

This PR adds two additional checks to the `mkDirByPathSync(..)` function.

1. Add handling of "EISDIR".

2. Create a directory only if the path does not exist. Using additional condition `fs.existsSync(curDir)`
