### PR TITLE
allow logging tshark's fields for frames unknown by pcap2qlog but known by tshark (off by default)

### DIFF
--- a/src/flow/jsontoqlog.ts
+++ b/src/flow/jsontoqlog.ts
@@ -10,7 +10,7 @@ const writeFileAsync = promisify(fs.writeFile);
 
 export class JSONToQLog{
 
-    public static async TransformToQLog(jsonPath:string, outputDirectory:string,  originalFile: string, logRawPayloads: boolean, secretsPath?:string):Promise<qlog.IQLog> {
+    public static async TransformToQLog(jsonPath:string, outputDirectory:string,  originalFile: string, logRawPayloads: boolean, secretsPath?:string, logUnknownFramesFields: boolean = false):Promise<qlog.IQLog> {
 
         // assumptions:
         // - jsonPath and secretsPath are LOCAL (if it was a URL, it has to be pre-downloaded)
@@ -30,7 +30,7 @@ export class JSONToQLog{
 
         // TODO: properly deal with different versions of QUIC and address the correct parser
         // see how we did this in @quictools/qlog-schema and replicate something similar here
-        let qlog:qlog.IQLog = ParserPCAP.Parse( jsonContents, originalFile, logRawPayloads, secretsContents );
+        let qlog:qlog.IQLog = ParserPCAP.Parse( jsonContents, originalFile, logRawPayloads, secretsContents, logUnknownFramesFields );
 
         // we could write this to file directly now
         // BUT we want to aggregate possible different IQLogs together in 1 combined/grouped IQLog before writing the final output

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,7 @@ let output_directory: string     = args.o || args.output    || "/srv/qvis-cache"
 let output_path: string          = args.p || args.outputpath;   // output will be placed in args.p  and temp storage is  args.o/inputs/
 let tsharkLocation: string       = args.t || args.tshark || "/wireshark/run/tshark"; // Path to the TShark executable
 let logRawPayloads: boolean      = args.r || args.raw || false; // If set to false, raw decrypted payloads will not be logged. This is default behaviour as payloads have a huge impact on log size.
+let logUnkFramesFields: boolean  = args.u || args.logunknownframesfields || false; // if set to true, adds to the qlog file the fields of the unknown frames present in the pcap parsed by TShark
 
 if( !input_file && !input_list ){
     console.error("No input file or list of files specified, use --input or --list");
@@ -217,7 +218,7 @@ async function Flow() {
 
         try{
             // we don't write to file here, but pass the qlog object around directly to write a combined file later
-            capt.qlog = await JSONToQLog.TransformToQLog( capt.capture, tempDirectory, capt.capture_original, logRawPayloads, capt.secrets );
+            capt.qlog = await JSONToQLog.TransformToQLog( capt.capture, tempDirectory, capt.capture_original, logRawPayloads, capt.secrets, logUnkFramesFields );
         }
         catch(e){
             // console.error("ERROR transforming", e);


### PR DESCRIPTION
Hello,

Some people are currently working on QUIC extensions involving new frames that are not part of the standard, such as multipath or FEC.

I have some FEC-specific frames that I added to the tshark dissector but the fields of those frames are ignored by `pcap2qlog` even if they are present in the tshark dissection. This pull requests adds the `--logunknownframesfields` CLI flag that, when set, makes `pcap2qlog` copy the fields known by tshark in the qlog description of the unknown frame. 

Here is an example of what it practically does. I added to tshark the dissection of the RECOVERED frame for FEC. Without the pull-request, a packet containing this frame looks like this in the qlog output:

```
"frames": [
    {
        "frame_type": "unknown_frame_type",
        "raw_frame_type": "43",
    }
]
```
When using the code of this pull request and setting the `--logunknownframesfields` CLI flag, pcap2qlog adds the fields parsed by tshark under the `raw_frame_content` field of the frame :
```
"frames": [
    {
        "frame_type": "unknown_frame_type",
        "raw_frame_type": "43",
        "raw_frame_content": {
                "quic.frame_type": "43",
                "quic.recovered.n_symbols": "1",
                "quic.recovered.first_packet": "0x00000000000017e3",
                "quic.recovered.recovered_src_fpi": "6109"
        }
    }
]
```

When the `--logunknownframesfields` flag is not set, the frame is exactly the same as without the code of this pull request, which means that the `raw_frame_content` is not even present.

Do not hesitate to let me know if you need some modifications of the code before merging. Also, I have no problem at all if you prefer not adding this feature at all. :-)

François 
