### PR TITLE
allow formatting the time in microseconds in the qlog output (stays in milliseconds by default)

### DIFF
--- a/src/flow/jsontoqlog.ts
+++ b/src/flow/jsontoqlog.ts
@@ -10,7 +10,7 @@ const writeFileAsync = promisify(fs.writeFile);
 
 export class JSONToQLog{
 
-    public static async TransformToQLog(jsonPath:string, outputDirectory:string,  originalFile: string, logRawPayloads: boolean, secretsPath?:string, logUnknownFramesFields: boolean = false):Promise<qlog.IQLog> {
+    public static async TransformToQLog(jsonPath:string, outputDirectory:string,  originalFile: string, logRawPayloads: boolean, timeUnit: "ms" | "us", secretsPath?:string, logUnknownFramesFields: boolean = false):Promise<qlog.IQLog> {
 
         // assumptions:
         // - jsonPath and secretsPath are LOCAL (if it was a URL, it has to be pre-downloaded)
@@ -30,7 +30,7 @@ export class JSONToQLog{
 
         // TODO: properly deal with different versions of QUIC and address the correct parser
         // see how we did this in @quictools/qlog-schema and replicate something similar here
-        let qlog:qlog.IQLog = ParserPCAP.Parse( jsonContents, originalFile, logRawPayloads, secretsContents, logUnknownFramesFields );
+        let qlog:qlog.IQLog = ParserPCAP.Parse( jsonContents, originalFile, logRawPayloads, timeUnit, secretsContents, logUnknownFramesFields );
 
         // we could write this to file directly now
         // BUT we want to aggregate possible different IQLogs together in 1 combined/grouped IQLog before writing the final output

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,13 @@ let output_path: string          = args.p || args.outputpath;   // output will b
 let tsharkLocation: string       = args.t || args.tshark || "/wireshark/run/tshark"; // Path to the TShark executable
 let logRawPayloads: boolean      = args.r || args.raw || false; // If set to false, raw decrypted payloads will not be logged. This is default behaviour as payloads have a huge impact on log size.
 let logUnkFramesFields: boolean  = args.u || args.logunknownframesfields || false; // if set to true, adds to the qlog file the fields of the unknown frames present in the pcap parsed by TShark
+let unchecked_time_unit: string  = args.T || args.timeunit || "ms"; // default: "ms". Defines the time unit in which to encode the timestamp in the resulting qlog file. Can be aither "ms" (milliseconds) or "us" (microseconds).
+
+if (unchecked_time_unit != "ms" && unchecked_time_unit != "us") {
+    console.error("Invalid time unit. The time unit should be either ms or us. Received value: " + unchecked_time_unit);
+    process.exit(1);
+}
+let time_unit: "ms" | "us" = unchecked_time_unit;
 
 if( !input_file && !input_list ){
     console.error("No input file or list of files specified, use --input or --list");
@@ -218,7 +225,7 @@ async function Flow() {
 
         try{
             // we don't write to file here, but pass the qlog object around directly to write a combined file later
-            capt.qlog = await JSONToQLog.TransformToQLog( capt.capture, tempDirectory, capt.capture_original, logRawPayloads, capt.secrets, logUnkFramesFields );
+            capt.qlog = await JSONToQLog.TransformToQLog( capt.capture, tempDirectory, capt.capture_original, logRawPayloads, time_unit, capt.secrets, logUnkFramesFields );
         }
         catch(e){
             // console.error("ERROR transforming", e);


### PR DESCRIPTION
Hello,

This pull requests adds the possibility to have a microsecond granularity for the timestamps present in the final qlog file. We can now obtain a microsecond granularity from the CLI by using the `--timeunit=us` CLI parameter.

By default, it behaves exactly as before, i.e. the default granularity is still in milliseconds (same as using `--timeunit=ms`).

If you are OK with the functionnality brought by this PR, do not hesitate to let me know if you want me to update the code for whatever reason, including coding style. :-) 

François