### PR TITLE
Emit Stream frame length correctly

### DIFF
--- a/src/parsers/ParserPCAP.ts
+++ b/src/parsers/ParserPCAP.ts
@@ -915,7 +915,7 @@ export class ParserPCAP {
                 stream_id: tsharkStreamFrame["quic.stream.stream_id"],
 
                 offset: tsharkStreamFrame['quic.frame_type_tree']['quic.stream.off'] === "1" ? tsharkStreamFrame["quic.stream.offset"] : "0",
-                length: tsharkStreamFrame["quic.stream.length"],
+                length: ((tsharkStreamFrame["quic.stream_data"].length + 1) / 3).toString(), // Data is hex encoded like 00:00:00:00
 
                 fin: tsharkStreamFrame["quic.frame_type_tree"]["quic.stream.fin"] === "1",
                 // raw: logRawPayloads ? tsharkStreamFrame["quic.stream_data"].replace(/:/g, '') : undefined,


### PR DESCRIPTION
The property `quic.stream.length` that the tool uses doesn't seem to be emitted
by wireshark for frames that carry no explicit length information (stream frame is
at the end of the packet). In that case the generated qlog will not have a length field.

To fix this, we calculate the length based on the data in the frame (which is correctly
emitted).

Fixes #7