### PR TITLE
fix TLS error in praseing PCAP

### DIFF
--- a/src/parsers/ParserPCAP.ts
+++ b/src/parsers/ParserPCAP.ts
@@ -135,7 +135,7 @@ export class ParserPCAP {
 
                             let foundCryptoFrame = undefined;
                             for ( const rawFrame of rawFrames ) {
-                                if ( PCAPUtil.ensurePathExists("tls.handshake/tls.handshake.type", rawFrame, false ) ) {
+                                if ( PCAPUtil.ensurePathExists("tls/tls.handshake/tls.handshake.type", rawFrame, false ) ) {
                                     foundCryptoFrame = rawFrame;
                                     break;
                                 }
@@ -145,7 +145,7 @@ export class ParserPCAP {
                                 this.exit("ParserPCAP: no tls info known for the first QUIC initial, not supported! Are you sure the trace decrypted?", rawPacket, rawPacket["quic.frame"] );
                             }
                             else {
-                                if ( foundCryptoFrame["tls.handshake"]["tls.handshake.type"] !== "1" ){ // 1 === ClientHello. 2 === ServerHello
+                                if ( foundCryptoFrame["tls"]["tls.handshake"]["tls.handshake.type"] !== "1" ){ // 1 === ClientHello. 2 === ServerHello
                                     this.exit("ParserPCAP: first QUIC initial in this trace is ServerHello. Pcap2qlog needs the ClientHello to work properly.", rawPackets);
                                 }
                                 else {


### PR DESCRIPTION
fix TLS error in praseing PCAP
In version 3.6.5 of tshark，there is a problem when convert pcap to qlog.
`{
    "qlog_version": "draft-01",
    "description": "",
    "traces": [
        {
            "error_description": "Error: ParserPCAP: no tls info known for the first QUIC initial, not supported! Are you sure the trace decrypted? : [object Object],`
I noticed that some fields changed when tshark converted the JSON file.
`            "quic.frame": [
              {
                "quic.frame_type": "6",
                "quic.crypto.offset": "0",
                "quic.crypto.length": "90",
                "quic.crypto.crypto_data": "",
                "tls": {
                  "tls.handshake": {
                    "tls.handshake.type": "2",`
So I changed the logic to identify an encrypted frame.

